### PR TITLE
Fix the score dialog bug

### DIFF
--- a/src/components/QuizSection/QuizSection.jsx
+++ b/src/components/QuizSection/QuizSection.jsx
@@ -46,7 +46,7 @@ const QuizSection = () => {
           setQuestionNum(questionNum + 1);
         }
       }
-    } else if (lives > 1) {
+    } else if (option && lives > 1) {
       setAffirmation('tryAgain');
       setQuizState('affirmation');
     } else {

--- a/src/pages/Game Finished/Dialogs/PlayAgainDialog.jsx
+++ b/src/pages/Game Finished/Dialogs/PlayAgainDialog.jsx
@@ -1,11 +1,36 @@
-import React from "react";
+import React, { useEffect } from "react";
 import "./Dialogs.scss";
 import character from "../../../assets/svg/PlayAgain_Character.svg";
 import { useSetAtom } from "jotai";
-import { appStateAtom } from "../../../store/atoms";
+import { appStateAtom, gameFinishedAtom, scoreAtom,affirmationAtom,correctOptionAtom, questionAtom } from "../../../store/atoms";
 
 export default function PlayAgainDialog() {
   const setAppState = useSetAtom(appStateAtom);
+  const setGameFinished = useSetAtom(gameFinishedAtom);
+  const setScore = useSetAtom(scoreAtom);
+  const setAffirmationAtom = useSetAtom(affirmationAtom);
+  const setCorrectOptionAtom = useSetAtom(correctOptionAtom); 
+  const setQuestionNum = useSetAtom(questionAtom);
+
+  const handlePlayAgain = () => {
+    setAppState("welcome")
+    //reset page
+    setGameFinished('score')
+    setScore(0)
+    setAffirmationAtom('')
+    setCorrectOptionAtom('')
+    setQuestionNum(1)
+  }
+
+  const handleSeeOtherGames = () =>{
+    setAppState("home")
+    //reset page
+    setGameFinished('score')
+    setScore(0)
+    setAffirmationAtom('')
+    setCorrectOptionAtom('')
+    setQuestionNum(1)
+  }
 
   return (
     <div className="wrapper">
@@ -19,10 +44,10 @@ export default function PlayAgainDialog() {
           <span>- Louis Armstrong</span>
         </div>
         <div className="button-container centralized">
-          <button onClick={() => setAppState("welcome")} className="primary">
+          <button onClick={()=>handlePlayAgain()} className="primary">
             PLAY AGAIN
           </button>
-          <button onClick={() => setAppState("home")} className="secondary">
+          <button onClick={() => handleSeeOtherGames()} className="secondary">
             SEE OTHER GAMES
           </button>
           <button

--- a/src/pages/Game Finished/GameFinished.jsx
+++ b/src/pages/Game Finished/GameFinished.jsx
@@ -3,8 +3,7 @@ import PlayAgainDialog from './Dialogs/PlayAgainDialog';
 import ScoreDialog from './Dialogs/ScoreDialog';
 import { useAtomValue } from 'jotai';
 import { gameFinishedAtom } from '../../store/atoms';
-// import NextLevel from './Dialogs/NextLevelDialog';
-// import SteakDialog from './Dialogs/StreakDialog';  
+
 
 export default function GameFinished() {
 
@@ -12,7 +11,7 @@ export default function GameFinished() {
 
   return (
     <div className='game-finished'>
-      {gameFinished === 'score' ? <ScoreDialog />  : <PlayAgainDialog />}      
+      {gameFinished === 'score' ? <ScoreDialog /> : <PlayAgainDialog />}
     </div>
   )
 }

--- a/src/pages/Game Finished/GameFinished.jsx
+++ b/src/pages/Game Finished/GameFinished.jsx
@@ -12,7 +12,7 @@ export default function GameFinished() {
 
   return (
     <div className='game-finished'>
-      {gameFinished == 'score' ? <ScoreDialog />  : <PlayAgainDialog />}      
+      {gameFinished === 'score' ? <ScoreDialog />  : <PlayAgainDialog />}      
     </div>
   )
 }

--- a/src/pages/Quiz/Affirmation/Affirmation.jsx
+++ b/src/pages/Quiz/Affirmation/Affirmation.jsx
@@ -52,26 +52,7 @@ export default function Affirmation() {
   const correctOption = useAtomValue(correctOptionAtom);
 
   const handleResponseBtn = () => {
-    // if(affirmation == 'success' || affirmation == 'fail'){
-    //   if (affirmation === 'success') {
-    //     setScore((prev) => prev + 1);
-    //   } else {
-    //     setLives(lives - 1);
-    //     if(lives == 1){
-    //       setOverlay('lives');
-    //       setQuizState('overlay');
-    //       return;
-    //     }
-    //   }
-    //   if(questionNum === totalQuestions){
-    //     setAppState('game-finished');
-    //   } else {
-    //     setQuestionNum(questionNum + 1);
-    //     setQuizState('quiz');
-    //   }
-    // } else{
-    //     setQuizState('quiz');
-    // }
+
     if (affirmation == "success") {
       setScore((prev) => prev + 1);
       if (questionNum === totalQuestions) {
@@ -98,7 +79,7 @@ export default function Affirmation() {
           className="background-rectangle"
           style={{ backgroundColor: bgColor }}
         >
-            <section className="tip-try-again">{sentence}</section>
+          <section className="tip-try-again">{sentence}</section>
           <button
             className="ButtonResponse"
             id="ButtonResponse"
@@ -116,7 +97,7 @@ export default function Affirmation() {
             className="background-rectangle"
             style={{ backgroundColor: bgColor }}
           >
-              <section className="tip">{sentence}</section>
+            <section className="tip">{sentence}</section>
             <button
               className="ButtonResponse"
               id="ButtonResponse"
@@ -134,10 +115,10 @@ export default function Affirmation() {
               className="background-rectangle"
               style={{ backgroundColor: bgColor }}
             >
-                <section className="tip">
-                  {sentence}
-                  <span>{correctOption}</span>
-                </section>
+              <section className="tip">
+                {sentence}
+                <span>{correctOption}</span>
+              </section>
               <button
                 className="ButtonResponse"
                 id="ButtonResponse"
@@ -150,32 +131,6 @@ export default function Affirmation() {
           : null}
   </div>
 
-    // <div className="container">
-    //   <div className="overlay"></div>
-    //   <img src={pic} className="beater" />
-    //   <div
-    //     className="background-rectangle"
-    //     style={{ backgroundColor: bgColor }}
-    //   >
-    //     {affirmation === "tryAgain" ? (
-    //       <section className="tip-try-again">{sentence}</section>
-    //     ) : affirmation === "success" ? (
-    //       <section className="tip">{sentence}</section>
-    //     ) : affirmation === "fail"?(
-    //       <section className="tip">
-    //         {sentence}
-    //         <span>{correctOption}</span>
-    //       </section>
-    //     ):null}
 
-    //     <button
-    //       className="ButtonResponse"
-    //       id="ButtonResponse"
-    //       onClick={handleResponseBtn}
-    //     >
-    //       {buttonText}
-    //     </button>
-    //   </div>
-    // </div>
   );
 }

--- a/src/pages/Quiz/Affirmation/Affirmation.jsx
+++ b/src/pages/Quiz/Affirmation/Affirmation.jsx
@@ -89,33 +89,93 @@ export default function Affirmation() {
     }
   };
 
-  return (
-    <div className="container">
-      <div className="overlay"></div>
-      <img src={pic} className="beater" />
-      <div
-        className="background-rectangle"
-        style={{ backgroundColor: bgColor }}
-      >
-        {affirmation === "tryAgain" ? (
-          <section className="tip-try-again">{sentence}</section>
-        ) : affirmation === "success" ? (
-          <section className="tip">{sentence}</section>
-        ) : affirmation === "fail"?(
-          <section className="tip">
-            {sentence}
-            <span>{correctOption}</span>
-          </section>
-        ):null}
-
-        <button
-          className="ButtonResponse"
-          id="ButtonResponse"
-          onClick={handleResponseBtn}
+  return (<div>
+    {affirmation === "tryAgain" ?
+      <div className="container">
+        <div className="overlay"></div>
+        <img src={pic} className="beater" />
+        <div
+          className="background-rectangle"
+          style={{ backgroundColor: bgColor }}
         >
-          {buttonText}
-        </button>
+            <section className="tip-try-again">{sentence}</section>
+          <button
+            className="ButtonResponse"
+            id="ButtonResponse"
+            onClick={handleResponseBtn}
+          >
+            {buttonText}
+          </button>
+        </div>
       </div>
-    </div>
+      : affirmation === "success" ?
+        <div className="container">
+          <div className="overlay"></div>
+          <img src={pic} className="beater" />
+          <div
+            className="background-rectangle"
+            style={{ backgroundColor: bgColor }}
+          >
+              <section className="tip">{sentence}</section>
+            <button
+              className="ButtonResponse"
+              id="ButtonResponse"
+              onClick={handleResponseBtn}
+            >
+              {buttonText}
+            </button>
+          </div>
+        </div>
+        : affirmation === "fail" ?
+          <div className="container">
+            <div className="overlay"></div>
+            <img src={pic} className="beater" />
+            <div
+              className="background-rectangle"
+              style={{ backgroundColor: bgColor }}
+            >
+                <section className="tip">
+                  {sentence}
+                  <span>{correctOption}</span>
+                </section>
+              <button
+                className="ButtonResponse"
+                id="ButtonResponse"
+                onClick={handleResponseBtn}
+              >
+                {buttonText}
+              </button>
+            </div>
+          </div>
+          : null}
+  </div>
+
+    // <div className="container">
+    //   <div className="overlay"></div>
+    //   <img src={pic} className="beater" />
+    //   <div
+    //     className="background-rectangle"
+    //     style={{ backgroundColor: bgColor }}
+    //   >
+    //     {affirmation === "tryAgain" ? (
+    //       <section className="tip-try-again">{sentence}</section>
+    //     ) : affirmation === "success" ? (
+    //       <section className="tip">{sentence}</section>
+    //     ) : affirmation === "fail"?(
+    //       <section className="tip">
+    //         {sentence}
+    //         <span>{correctOption}</span>
+    //       </section>
+    //     ):null}
+
+    //     <button
+    //       className="ButtonResponse"
+    //       id="ButtonResponse"
+    //       onClick={handleResponseBtn}
+    //     >
+    //       {buttonText}
+    //     </button>
+    //   </div>
+    // </div>
   );
 }

--- a/src/pages/Quiz/Affirmation/Affirmation.jsx
+++ b/src/pages/Quiz/Affirmation/Affirmation.jsx
@@ -101,12 +101,12 @@ export default function Affirmation() {
           <section className="tip-try-again">{sentence}</section>
         ) : affirmation === "success" ? (
           <section className="tip">{sentence}</section>
-        ) : (
+        ) : affirmation === "fail"?(
           <section className="tip">
             {sentence}
             <span>{correctOption}</span>
           </section>
-        )}
+        ):null}
 
         <button
           className="ButtonResponse"


### PR DESCRIPTION
(1) Find the score dialog bug, because it was originally set as "end-game" in the **ScoreDialog.jsx** file, so no matter what we choose for the quiz screen, the score dialog can only show up once, then the next time when the game ends, it will turn to playAgainDialog page and will never show the ScoreDialog.
(2) Because of the logical problem, I also fix the **Affirmation.jsx** page bug in case the second time initialize the quiz, it might pop up.


Now the ScoreDialog can pop up when the game ends.